### PR TITLE
Enhancement: Add rule set for PHP 7.2

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/.php_cs
+++ b/.php_cs
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php74($license->header()));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php72($license->header()));
 
 $config->getFinder()
     ->exclude([

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...main`][1.0.0...main].
+For a full diff see [`1.1.0...main`][1.1.0...main].
+
+## [`1.1.0`][1.1.0]
+
+For a full diff see [`1.0.0...1.1.0`][1.0.0...1.1.0].
+
+### Added
+
+* Added rule set for PHP 7.2 ([#12]), by [@localheinz]
 
 ### Changed
 
@@ -23,9 +31,11 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [1.0.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/tag/1.0.1
 
 [b9012df...1.0.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/b9012df...1.0.0
-[1.0.0...main]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.0.0...main
+[1.0.0...1.1.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.0.0...1.1.0
+[1.1.0...main]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.1.0...main
 
 [#9]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/9
 [#11]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/10
+[#12]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/12
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ composer require --dev gansel/php-cs-fixer-config
 
 Pick one of the rule sets:
 
+* [`Ergebnis\PhpCsFixer\RuleSet\Php72`](src/RuleSet/Php72.php)
 * [`Ergebnis\PhpCsFixer\RuleSet\Php74`](src/RuleSet/Php74.php)
 
 Create a configuration file `.php_cs` in the root of your project:

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Gansel Rechtsanwälte
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config
+ */
+
+namespace Gansel\PhpCsFixer\Config\RuleSet;
+
+use PhpCsFixer\Fixer;
+
+final class Php72 extends AbstractRuleSet
+{
+    protected $name = 'gansel (PHP 7.2)';
+
+    protected $rules = [
+        '@DoctrineAnnotation' => true,
+        '@Symfony' => true,
+        'array_indentation' => true,
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
+        'blank_line_before_statement' => [
+            'statements' => [
+                'break',
+                'continue',
+                'declare',
+                'default',
+                'die',
+                'do',
+                'exit',
+                'for',
+                'foreach',
+                'goto',
+                'if',
+                'include',
+                'include_once',
+                'require',
+                'require_once',
+                'return',
+                'switch',
+                'throw',
+                'try',
+                'while',
+            ],
+        ],
+        'combine_consecutive_issets' => true,
+        'combine_consecutive_unsets' => true,
+        'compact_nullable_typehint' => true,
+        'declare_strict_types' => true,
+        'explicit_string_variable' => true,
+        'header_comment' => false,
+        'linebreak_after_opening_tag' => true,
+        'list_syntax' => [
+            'syntax' => 'short',
+        ],
+        'logical_operators' => true,
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+        ],
+        'multiline_whitespace_before_semicolons' => true,
+        'native_function_invocation' => [
+            'include' => [
+                '@compiler_optimized',
+            ],
+            'scope' => 'namespaced',
+        ],
+        'no_null_property_initialization' => true,
+        'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'nullable_type_declaration_for_default_null_value' => false,
+        'ordered_class_elements' => true,
+        'ordered_imports' => [
+            'imports_order' => [
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+            ],
+         ],
+        'php_unit_construct' => true,
+        'php_unit_dedicate_assert' => [
+            'target' => 'newest',
+        ],
+        'php_unit_dedicate_assert_internal_type' => true,
+        'php_unit_strict' => false,
+        'php_unit_test_annotation' => [
+            'style' => 'annotation',
+        ],
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'self',
+        ],
+        'phpdoc_no_empty_return' => true,
+        'protected_to_private' => true,
+        'psr0' => true,
+        'psr4' => true,
+        'return_assignment' => false,
+        'single_line_throw' => false,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'ternary_to_null_coalescing' => true,
+        'visibility_required' => [
+            'elements' => [
+                'const',
+                'method',
+                'property',
+            ],
+        ],
+        'void_return' => true,
+    ];
+
+    protected $targetPhpVersion = 70200;
+}

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Gansel Rechtsanwälte
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config
+ */
+
+namespace Gansel\PhpCsFixer\Config\Test\Unit\RuleSet;
+
+use PhpCsFixer\Fixer;
+
+/**
+ * @internal
+ *
+ * @covers \Gansel\PhpCsFixer\Config\RuleSet\AbstractRuleSet
+ * @covers \Gansel\PhpCsFixer\Config\RuleSet\Php74
+ */
+final class Php72Test extends AbstractRuleSetTestCase
+{
+    protected $name = 'gansel (PHP 7.2)';
+
+    protected $rules = [
+        '@DoctrineAnnotation' => true,
+        '@Symfony' => true,
+        'array_indentation' => true,
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
+        'blank_line_before_statement' => [
+            'statements' => [
+                'break',
+                'continue',
+                'declare',
+                'default',
+                'die',
+                'do',
+                'exit',
+                'for',
+                'foreach',
+                'goto',
+                'if',
+                'include',
+                'include_once',
+                'require',
+                'require_once',
+                'return',
+                'switch',
+                'throw',
+                'try',
+                'while',
+            ],
+        ],
+        'combine_consecutive_issets' => true,
+        'combine_consecutive_unsets' => true,
+        'compact_nullable_typehint' => true,
+        'declare_strict_types' => true,
+        'explicit_string_variable' => true,
+        'header_comment' => false,
+        'linebreak_after_opening_tag' => true,
+        'list_syntax' => [
+            'syntax' => 'short',
+        ],
+        'logical_operators' => true,
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+        ],
+        'multiline_whitespace_before_semicolons' => true,
+        'native_function_invocation' => [
+            'include' => [
+                '@compiler_optimized',
+            ],
+            'scope' => 'namespaced',
+        ],
+        'no_null_property_initialization' => true,
+        'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'nullable_type_declaration_for_default_null_value' => false,
+        'ordered_class_elements' => true,
+        'ordered_imports' => [
+            'imports_order' => [
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+            ],
+        ],
+        'php_unit_construct' => true,
+        'php_unit_dedicate_assert' => [
+            'target' => 'newest',
+        ],
+        'php_unit_dedicate_assert_internal_type' => true,
+        'php_unit_strict' => false,
+        'php_unit_test_annotation' => [
+            'style' => 'annotation',
+        ],
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'self',
+        ],
+        'phpdoc_no_empty_return' => true,
+        'protected_to_private' => true,
+        'psr0' => true,
+        'psr4' => true,
+        'return_assignment' => false,
+        'single_line_throw' => false,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'ternary_to_null_coalescing' => true,
+        'visibility_required' => [
+            'elements' => [
+                'const',
+                'method',
+                'property',
+            ],
+        ],
+        'void_return' => true,
+    ];
+
+    protected $targetPhpVersion = 70200;
+}


### PR DESCRIPTION
This PR

* [x] adds a `Php72` rule set for PHP 7.2

💁‍♂️ Yes, it configures the same rules as `Php74`, but now both rule sets can evolve independently and enable or disable PHP-version-specific fixers.