### PR TITLE
Enhancement: Enable align_multiline_comment fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 ### Changed
 
 * Allowed installation with PHP 8.0 ([#24]), by [@localheinz]
+* Enabled `align_multiline_comment` fixer  ([#26]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -54,5 +55,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#12]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/12
 [#21]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/21
 [#24]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/24
+[#26]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/26
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -20,7 +20,7 @@ final class Php72 extends AbstractRuleSet
     protected $name = 'gansel (PHP 7.2)';
 
     protected $rules = [
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => true,
         'array_indentation' => true,
         'array_push' => false,
         'array_syntax' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -20,7 +20,7 @@ final class Php74 extends AbstractRuleSet
     protected $name = 'gansel (PHP 7.4)';
 
     protected $rules = [
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => true,
         'array_indentation' => true,
         'array_push' => false,
         'array_syntax' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -26,7 +26,7 @@ final class Php72Test extends AbstractRuleSetTestCase
     protected $name = 'gansel (PHP 7.2)';
 
     protected $rules = [
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => true,
         'array_indentation' => true,
         'array_push' => false,
         'array_syntax' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -26,7 +26,7 @@ final class Php74Test extends AbstractRuleSetTestCase
     protected $name = 'gansel (PHP 7.4)';
 
     protected $rules = [
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => true,
         'array_indentation' => true,
         'array_push' => false,
         'array_syntax' => [


### PR DESCRIPTION
This PR

* [x] enables the `align_multline_comment` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/align_multiline_comment.rst.