### PR TITLE
Enhancement: Enable array_push fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 
 * Allowed installation with PHP 8.0 ([#24]), by [@localheinz]
 * Enabled `align_multiline_comment` fixer  ([#26]), by [@localheinz]
+* Enabled `array_push` fixer  ([#27]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -56,5 +57,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#21]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/21
 [#24]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/24
 [#26]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/26
+[#27]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/27
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -22,7 +22,7 @@ final class Php72 extends AbstractRuleSet
     protected $rules = [
         'align_multiline_comment' => true,
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -22,7 +22,7 @@ final class Php74 extends AbstractRuleSet
     protected $rules = [
         'align_multiline_comment' => true,
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -28,7 +28,7 @@ final class Php72Test extends AbstractRuleSetTestCase
     protected $rules = [
         'align_multiline_comment' => true,
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -28,7 +28,7 @@ final class Php74Test extends AbstractRuleSetTestCase
     protected $rules = [
         'align_multiline_comment' => true,
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `align_multline_comment` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/alias/array_push.rst.