### PR TITLE
Enhancement: Enable combine_nested_dirname fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Allowed installation with PHP 8.0 ([#24]), by [@localheinz]
 * Enabled `align_multiline_comment` fixer  ([#26]), by [@localheinz]
 * Enabled `array_push` fixer  ([#27]), by [@localheinz]
+* Enabled `combine_nested_dirname` fixer  ([#28]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -58,5 +59,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#24]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/24
 [#26]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/26
 [#27]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/27
+[#28]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/28
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -71,7 +71,7 @@ final class Php72 extends AbstractRuleSet
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => false,
         'compact_nullable_typehint' => true,
         'concat_space' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -71,7 +71,7 @@ final class Php74 extends AbstractRuleSet
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => false,
         'compact_nullable_typehint' => true,
         'concat_space' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -77,7 +77,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => false,
         'compact_nullable_typehint' => true,
         'concat_space' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -77,7 +77,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => false,
         'compact_nullable_typehint' => true,
         'concat_space' => true,


### PR DESCRIPTION
This PR

* [x] enables the `combine_nested_dirname` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/combine_nested_dirname.rst.