### PR TITLE
Enhancement: Enable dir_constant fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `align_multiline_comment` fixer  ([#26]), by [@localheinz]
 * Enabled `array_push` fixer  ([#27]), by [@localheinz]
 * Enabled `combine_nested_dirname` fixer  ([#28]), by [@localheinz]
+* Enabled `dir_constant` fixer  ([#29]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -60,5 +61,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#26]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/26
 [#27]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/27
 [#28]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/28
+[#29]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/29
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -79,7 +79,7 @@ final class Php72 extends AbstractRuleSet
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
-        'dir_constant' => false,
+        'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [
             'operator' => ':',
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -79,7 +79,7 @@ final class Php74 extends AbstractRuleSet
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
-        'dir_constant' => false,
+        'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [
             'operator' => ':',
         ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -85,7 +85,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
-        'dir_constant' => false,
+        'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [
             'operator' => ':',
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -85,7 +85,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
-        'dir_constant' => false,
+        'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [
             'operator' => ':',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `dir_constant` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/language_construct/dir_constant.rst.