### PR TITLE
Enhancement: Enable ereg_to_preg fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `array_push` fixer  ([#27]), by [@localheinz]
 * Enabled `combine_nested_dirname` fixer  ([#28]), by [@localheinz]
 * Enabled `dir_constant` fixer  ([#29]), by [@localheinz]
+* Enabled `ereg_to_preg` fixer  ([#30]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -62,5 +63,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#27]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/27
 [#28]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/28
 [#29]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/29
+[#30]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/30
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -91,7 +91,7 @@ final class Php72 extends AbstractRuleSet
         'echo_tag_syntax' => true,
         'elseif' => true,
         'encoding' => true,
-        'ereg_to_preg' => false,
+        'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => false,
         'explicit_indirect_variable' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -91,7 +91,7 @@ final class Php74 extends AbstractRuleSet
         'echo_tag_syntax' => true,
         'elseif' => true,
         'encoding' => true,
-        'ereg_to_preg' => false,
+        'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => false,
         'explicit_indirect_variable' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -97,7 +97,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'echo_tag_syntax' => true,
         'elseif' => true,
         'encoding' => true,
-        'ereg_to_preg' => false,
+        'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => false,
         'explicit_indirect_variable' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -97,7 +97,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'echo_tag_syntax' => true,
         'elseif' => true,
         'encoding' => true,
-        'ereg_to_preg' => false,
+        'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => false,
         'explicit_indirect_variable' => false,


### PR DESCRIPTION
This PR

* [x] enables the `ereg_to_preg` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/alias/ereg_to_preg.rst.