### PR TITLE
Enhancement: Enable escape_implicit_backslashes fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `combine_nested_dirname` fixer  ([#28]), by [@localheinz]
 * Enabled `dir_constant` fixer  ([#29]), by [@localheinz]
 * Enabled `ereg_to_preg` fixer  ([#30]), by [@localheinz]
+* Enabled `escape_implicit_backslashes` fixer  ([#31]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -64,5 +65,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#28]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/28
 [#29]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/29
 [#30]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/30
+[#31]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/31
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -93,7 +93,7 @@ final class Php72 extends AbstractRuleSet
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => false,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
         'final_class' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -93,7 +93,7 @@ final class Php74 extends AbstractRuleSet
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => false,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
         'final_class' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -99,7 +99,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => false,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
         'final_class' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -99,7 +99,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => false,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
         'final_class' => false,


### PR DESCRIPTION
This PR

* [x] enables the `escape_implicit_backslashes` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/string_notation/escape_implicit_backslashes.rst.