### PR TITLE
Enhancement: Enable explicit_indirect_variable fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `dir_constant` fixer  ([#29]), by [@localheinz]
 * Enabled `ereg_to_preg` fixer  ([#30]), by [@localheinz]
 * Enabled `escape_implicit_backslashes` fixer  ([#31]), by [@localheinz]
+* Enabled `explicit_indirect_variable` fixer ([#32]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -66,5 +67,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#29]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/29
 [#30]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/30
 [#31]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/31
+[#32]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/32
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -94,7 +94,7 @@ final class Php72 extends AbstractRuleSet
         'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
         'final_internal_class' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -94,7 +94,7 @@ final class Php74 extends AbstractRuleSet
         'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
         'final_internal_class' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -100,7 +100,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
         'final_internal_class' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -100,7 +100,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'ereg_to_preg' => true,
         'error_suppression' => false,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
         'final_internal_class' => false,


### PR DESCRIPTION
This PR

* [x] enables the `explicit_indirect_variable` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/language_construct/explicit_indirect_variable.rst.