### PR TITLE
Enhancement: Enable final_internal_class fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `ereg_to_preg` fixer  ([#30]), by [@localheinz]
 * Enabled `escape_implicit_backslashes` fixer  ([#31]), by [@localheinz]
 * Enabled `explicit_indirect_variable` fixer ([#32]), by [@localheinz]
+* Enabled `final_internal_class` fixer ([#34]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -68,5 +69,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#30]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/30
 [#31]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/31
 [#32]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/32
+[#34]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/34
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -97,7 +97,7 @@ final class Php72 extends AbstractRuleSet
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'final_public_method_for_abstract_class' => false,
         'fopen_flag_order' => false,
         'fopen_flags' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -97,7 +97,7 @@ final class Php74 extends AbstractRuleSet
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'final_public_method_for_abstract_class' => false,
         'fopen_flag_order' => false,
         'fopen_flags' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -103,7 +103,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'final_public_method_for_abstract_class' => false,
         'fopen_flag_order' => false,
         'fopen_flags' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -103,7 +103,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_class' => false,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'final_public_method_for_abstract_class' => false,
         'fopen_flag_order' => false,
         'fopen_flags' => false,


### PR DESCRIPTION
This PR

* [x] enables the `final_internal_class` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/class_notation/final_internal_class.rst.