### PR TITLE
Enhancement: Enable function_to_constant fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `escape_implicit_backslashes` fixer ([#31]), by [@localheinz]
 * Enabled `explicit_indirect_variable` fixer ([#32]), by [@localheinz]
 * Enabled `final_internal_class` fixer ([#34]), by [@localheinz]
+* Enabled `function_to_constant` fixer ([#35]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -70,5 +71,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#31]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/31
 [#32]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/32
 [#34]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/34
+[#35]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/35
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -104,7 +104,7 @@ final class Php72 extends AbstractRuleSet
         'full_opening_tag' => true,
         'fully_qualified_strict_types' => true,
         'function_declaration' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,
         'general_phpdoc_tag_rename' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -104,7 +104,7 @@ final class Php74 extends AbstractRuleSet
         'full_opening_tag' => true,
         'fully_qualified_strict_types' => true,
         'function_declaration' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,
         'general_phpdoc_tag_rename' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -110,7 +110,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'full_opening_tag' => true,
         'fully_qualified_strict_types' => true,
         'function_declaration' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,
         'general_phpdoc_tag_rename' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -110,7 +110,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'full_opening_tag' => true,
         'fully_qualified_strict_types' => true,
         'function_declaration' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,
         'general_phpdoc_tag_rename' => [


### PR DESCRIPTION
This PR

* [x] enables the `function_to_constant` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/language_construct/function_to_constant.rst.