### PR TITLE
Enhancement: Enable and configure global_namespace_import fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `explicit_indirect_variable` fixer ([#32]), by [@localheinz]
 * Enabled `final_internal_class` fixer ([#34]), by [@localheinz]
 * Enabled `function_to_constant` fixer ([#35]), by [@localheinz]
+* Enabled and configured `global_namespace_import` fixer ([#37]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -72,5 +73,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#32]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/32
 [#34]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/34
 [#35]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/35
+[#37]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/37
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -112,7 +112,11 @@ final class Php72 extends AbstractRuleSet
                 'inheritDocs' => 'inheritDoc',
             ],
         ],
-        'global_namespace_import' => false,
+        'global_namespace_import' => [
+            'import_classes' => false,
+            'import_constants' => false,
+            'import_functions' => false,
+        ],
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -112,7 +112,11 @@ final class Php74 extends AbstractRuleSet
                 'inheritDocs' => 'inheritDoc',
             ],
         ],
-        'global_namespace_import' => false,
+        'global_namespace_import' => [
+            'import_classes' => false,
+            'import_constants' => false,
+            'import_functions' => false,
+        ],
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -118,7 +118,11 @@ final class Php72Test extends AbstractRuleSetTestCase
                 'inheritDocs' => 'inheritDoc',
             ],
         ],
-        'global_namespace_import' => false,
+        'global_namespace_import' => [
+            'import_classes' => false,
+            'import_constants' => false,
+            'import_functions' => false,
+        ],
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -118,7 +118,11 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'inheritDocs' => 'inheritDoc',
             ],
         ],
-        'global_namespace_import' => false,
+        'global_namespace_import' => [
+            'import_classes' => false,
+            'import_constants' => false,
+            'import_functions' => false,
+        ],
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,


### PR DESCRIPTION
This PR

* [x] enables the `function_to_constant` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/import/global_namespace_import.rst.