### PR TITLE
Enhancement: Enable heredoc_to_nowdoc fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `final_internal_class` fixer ([#34]), by [@localheinz]
 * Enabled `function_to_constant` fixer ([#35]), by [@localheinz]
 * Enabled and configured `global_namespace_import` fixer ([#37]), by [@localheinz]
+* Enabled `heredoc_to_nowdoc` fixer ([#38]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -74,5 +75,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#34]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/34
 [#35]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/35
 [#37]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/37
+[#38]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/38
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -120,7 +120,7 @@ final class Php72 extends AbstractRuleSet
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,
-        'heredoc_to_nowdoc' => false,
+        'heredoc_to_nowdoc' => true,
         'implode_call' => false,
         'include' => true,
         'increment_style' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -120,7 +120,7 @@ final class Php74 extends AbstractRuleSet
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,
-        'heredoc_to_nowdoc' => false,
+        'heredoc_to_nowdoc' => true,
         'implode_call' => false,
         'include' => true,
         'increment_style' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -126,7 +126,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,
-        'heredoc_to_nowdoc' => false,
+        'heredoc_to_nowdoc' => true,
         'implode_call' => false,
         'include' => true,
         'increment_style' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -126,7 +126,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'group_import' => false,
         'header_comment' => false,
         'heredoc_indentation' => false,
-        'heredoc_to_nowdoc' => false,
+        'heredoc_to_nowdoc' => true,
         'implode_call' => false,
         'include' => true,
         'increment_style' => true,


### PR DESCRIPTION
This PR

* [x] enables the `heredoc_to_nowdoc ` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/string_notation/heredoc_to_nowdoc.rst.