### PR TITLE
Enhancement: Enable implode_call fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `function_to_constant` fixer ([#35]), by [@localheinz]
 * Enabled and configured `global_namespace_import` fixer ([#37]), by [@localheinz]
 * Enabled `heredoc_to_nowdoc` fixer ([#38]), by [@localheinz]
+* Enabled `implode_call` fixer ([#39]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -76,5 +77,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#35]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/35
 [#37]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/37
 [#38]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/38
+[#39]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/39
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -121,7 +121,7 @@ final class Php72 extends AbstractRuleSet
         'header_comment' => false,
         'heredoc_indentation' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -121,7 +121,7 @@ final class Php74 extends AbstractRuleSet
         'header_comment' => false,
         'heredoc_indentation' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -127,7 +127,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'header_comment' => false,
         'heredoc_indentation' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -127,7 +127,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'header_comment' => false,
         'heredoc_indentation' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,


### PR DESCRIPTION
This PR

* [x] enables the `implode_call ` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/implode_call.rst.