### PR TITLE
Enhancement: Enable is_null fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled and configured `global_namespace_import` fixer ([#37]), by [@localheinz]
 * Enabled `heredoc_to_nowdoc` fixer ([#38]), by [@localheinz]
 * Enabled `implode_call` fixer ([#39]), by [@localheinz]
+* Enabled `is_null` fixer ([#40]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -78,5 +79,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#37]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/37
 [#38]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/38
 [#39]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/39
+[#40]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/40
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -125,7 +125,7 @@ final class Php72 extends AbstractRuleSet
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,
-        'is_null' => false,
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -125,7 +125,7 @@ final class Php74 extends AbstractRuleSet
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,
-        'is_null' => false,
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -131,7 +131,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,
-        'is_null' => false,
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -131,7 +131,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'include' => true,
         'increment_style' => true,
         'indentation_type' => true,
-        'is_null' => false,
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,


### PR DESCRIPTION
This PR

* [x] enables the `is_null` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/language_construct/is_null.rst.