### PR TITLE
Enhancement: Enable method_chaining_indentation fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `heredoc_to_nowdoc` fixer ([#38]), by [@localheinz]
 * Enabled `implode_call` fixer ([#39]), by [@localheinz]
 * Enabled `is_null` fixer ([#40]), by [@localheinz]
+* Enabled `method_chaining_indentation` fixer ([#41]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -80,5 +81,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#38]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/38
 [#39]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/39
 [#40]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/40
+[#41]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/41
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -142,7 +142,7 @@ final class Php72 extends AbstractRuleSet
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'modernize_types_casting' => false,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -142,7 +142,7 @@ final class Php74 extends AbstractRuleSet
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'modernize_types_casting' => false,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -148,7 +148,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'modernize_types_casting' => false,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -148,7 +148,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'modernize_types_casting' => false,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,


### PR DESCRIPTION
This PR

* [x] enables the `method_chaining_indentation` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/whitespace/method_chaining_indentation.rst.