### PR TITLE
Enhancement: Enable modernize_types_casting fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `implode_call` fixer ([#39]), by [@localheinz]
 * Enabled `is_null` fixer ([#40]), by [@localheinz]
 * Enabled `method_chaining_indentation` fixer ([#41]), by [@localheinz]
+* Enabled `modernize_types_casting` fixer ([#42]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -82,5 +83,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#39]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/39
 [#40]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/40
 [#41]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/41
+[#42]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/42
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -143,7 +143,7 @@ final class Php72 extends AbstractRuleSet
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_types_casting' => false,
+        'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -143,7 +143,7 @@ final class Php74 extends AbstractRuleSet
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_types_casting' => false,
+        'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -149,7 +149,7 @@ final class Php72Test extends AbstractRuleSetTestCase
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_types_casting' => false,
+        'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -149,7 +149,7 @@ final class Php74Test extends AbstractRuleSetTestCase
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_types_casting' => false,
+        'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => false,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,


### PR DESCRIPTION
This PR

* [x] enables the `modernize_types_casting` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/cast_notation/modernize_types_casting.rst.