### PR TITLE
Enhancement: Enable multiline_comment_opening_closing fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `is_null` fixer ([#40]), by [@localheinz]
 * Enabled `method_chaining_indentation` fixer ([#41]), by [@localheinz]
 * Enabled `modernize_types_casting` fixer ([#42]), by [@localheinz]
+* Enabled `multiline_comment_opening_closing` fixer ([#43]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -84,5 +85,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#40]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/40
 [#41]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/41
 [#42]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/42
+[#43]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/43
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -144,7 +144,7 @@ final class Php72 extends AbstractRuleSet
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,
         'native_function_casing' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -144,7 +144,7 @@ final class Php74 extends AbstractRuleSet
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -150,7 +150,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -150,7 +150,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => false,
         'native_function_casing' => true,


### PR DESCRIPTION
This PR

* [x] enables the `multiline_comment_opening_closing` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/comment/multiline_comment_opening_closing.rst.