### PR TITLE
Enhancement: Enable native_constant_invocation fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `method_chaining_indentation` fixer ([#41]), by [@localheinz]
 * Enabled `modernize_types_casting` fixer ([#42]), by [@localheinz]
 * Enabled `multiline_comment_opening_closing` fixer ([#43]), by [@localheinz]
+* Enabled `native_constant_invocation` fixer ([#44]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -86,5 +87,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#41]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/41
 [#42]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/42
 [#43]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/43
+[#44]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/44
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -146,7 +146,7 @@ final class Php72 extends AbstractRuleSet
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -146,7 +146,7 @@ final class Php74 extends AbstractRuleSet
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -152,7 +152,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -152,7 +152,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [


### PR DESCRIPTION
This PR

* [x] enables the `native_constant_invocation` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/constant_notation/native_constant_invocation.rst.