### PR TITLE
Enhancement: Enable no_alias_functions fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `modernize_types_casting` fixer ([#42]), by [@localheinz]
 * Enabled `multiline_comment_opening_closing` fixer ([#43]), by [@localheinz]
 * Enabled `native_constant_invocation` fixer ([#44]), by [@localheinz]
+* Enabled `no_alias_functions` fixer ([#45]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -88,5 +89,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#42]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/42
 [#43]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/43
 [#44]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/44
+[#45]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/45
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -156,7 +156,7 @@ final class Php72 extends AbstractRuleSet
         ],
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
-        'no_alias_functions' => false,
+        'no_alias_functions' => true,
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -156,7 +156,7 @@ final class Php74 extends AbstractRuleSet
         ],
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
-        'no_alias_functions' => false,
+        'no_alias_functions' => true,
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -162,7 +162,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         ],
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
-        'no_alias_functions' => false,
+        'no_alias_functions' => true,
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -162,7 +162,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         ],
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
-        'no_alias_functions' => false,
+        'no_alias_functions' => true,
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_alias_functions` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/alias/no_alias_functions.rst.