### PR TITLE
Enhancement: Enable no_homoglyph_names fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `multiline_comment_opening_closing` fixer ([#43]), by [@localheinz]
 * Enabled `native_constant_invocation` fixer ([#44]), by [@localheinz]
 * Enabled `no_alias_functions` fixer ([#45]), by [@localheinz]
+* Enabled `no_homoglyph_names` fixer ([#46]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -90,5 +91,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#43]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/43
 [#44]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/44
 [#45]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/45
+[#46]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/46
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -183,7 +183,7 @@ final class Php72 extends AbstractRuleSet
                 'use_trait',
             ],
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -183,7 +183,7 @@ final class Php74 extends AbstractRuleSet
                 'use_trait',
             ],
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -189,7 +189,7 @@ final class Php72Test extends AbstractRuleSetTestCase
                 'use_trait',
             ],
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -189,7 +189,7 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'use_trait',
             ],
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_homoglyph_names` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/naming/no_homoglyph_names.rst.