### PR TITLE
Enhancement: Enable no_trailing_whitespace_in_string fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `native_constant_invocation` fixer ([#44]), by [@localheinz]
 * Enabled `no_alias_functions` fixer ([#45]), by [@localheinz]
 * Enabled `no_homoglyph_names` fixer ([#46]), by [@localheinz]
+* Enabled `no_trailing_whitespace_in_string` fixer ([#47]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -92,5 +93,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#44]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/44
 [#45]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/45
 [#46]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/46
+[#47]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/47
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -201,7 +201,7 @@ final class Php72 extends AbstractRuleSet
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => [
             'statements' => [
                 'break',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -201,7 +201,7 @@ final class Php74 extends AbstractRuleSet
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => [
             'statements' => [
                 'break',

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -207,7 +207,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => [
             'statements' => [
                 'break',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -207,7 +207,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => [
             'statements' => [
                 'break',


### PR DESCRIPTION
This PR

* [x] enables the `no_trailing_whitespace_in_string` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/string_notation/no_trailing_whitespace_in_string.rst.