### PR TITLE
Enhancement: Enable no_unneeded_final_method fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_alias_functions` fixer ([#45]), by [@localheinz]
 * Enabled `no_homoglyph_names` fixer ([#46]), by [@localheinz]
 * Enabled `no_trailing_whitespace_in_string` fixer ([#47]), by [@localheinz]
+* Enabled `no_unneeded_final_method` fixer ([#48]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -94,5 +95,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#45]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/45
 [#46]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/46
 [#47]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/47
+[#48]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/48
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -217,7 +217,7 @@ final class Php72 extends AbstractRuleSet
         'no_unneeded_curly_braces' => [
             'namespaces' => true,
         ],
-        'no_unneeded_final_method' => false,
+        'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => false,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -217,7 +217,7 @@ final class Php74 extends AbstractRuleSet
         'no_unneeded_curly_braces' => [
             'namespaces' => true,
         ],
-        'no_unneeded_final_method' => false,
+        'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => false,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -223,7 +223,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => [
             'namespaces' => true,
         ],
-        'no_unneeded_final_method' => false,
+        'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => false,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -223,7 +223,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => [
             'namespaces' => true,
         ],
-        'no_unneeded_final_method' => false,
+        'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => false,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,


### PR DESCRIPTION
This PR

* [x] enables the `no_unneeded_final_method` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/class_notation/no_unneeded_final_method.rst.