### PR TITLE
Enhancement: Enable no_unreachable_default_argument_value fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_homoglyph_names` fixer ([#46]), by [@localheinz]
 * Enabled `no_trailing_whitespace_in_string` fixer ([#47]), by [@localheinz]
 * Enabled `no_unneeded_final_method` fixer ([#48]), by [@localheinz]
+* Enabled `no_unreachable_default_argument_value` fixer ([#49]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -96,5 +97,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#46]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/46
 [#47]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/47
 [#48]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/48
+[#49]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/49
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -218,7 +218,7 @@ final class Php72 extends AbstractRuleSet
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unreachable_default_argument_value' => false,
+        'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,
         'no_unused_imports' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -218,7 +218,7 @@ final class Php74 extends AbstractRuleSet
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unreachable_default_argument_value' => false,
+        'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,
         'no_unused_imports' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -224,7 +224,7 @@ final class Php72Test extends AbstractRuleSetTestCase
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unreachable_default_argument_value' => false,
+        'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,
         'no_unused_imports' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -224,7 +224,7 @@ final class Php74Test extends AbstractRuleSetTestCase
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unreachable_default_argument_value' => false,
+        'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,
         'no_unused_imports' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_unreachable_default_argument_value` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/no_unreachable_default_argument_value.rst.