### PR TITLE
Enhancement: Enable no_useless_return fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_trailing_whitespace_in_string` fixer ([#47]), by [@localheinz]
 * Enabled `no_unneeded_final_method` fixer ([#48]), by [@localheinz]
 * Enabled `no_unreachable_default_argument_value` fixer ([#49]), by [@localheinz]
+* Enabled `no_useless_return` fixer ([#50]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -98,5 +99,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#47]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/47
 [#48]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/48
 [#49]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/49
+[#50]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/50
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -223,7 +223,7 @@ final class Php72 extends AbstractRuleSet
         'no_unset_on_property' => false,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_return' => false,
+        'no_useless_return' => true,
         'no_useless_sprintf' => false,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -223,7 +223,7 @@ final class Php74 extends AbstractRuleSet
         'no_unset_on_property' => false,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_return' => false,
+        'no_useless_return' => true,
         'no_useless_sprintf' => false,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -229,7 +229,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'no_unset_on_property' => false,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_return' => false,
+        'no_useless_return' => true,
         'no_useless_sprintf' => false,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -229,7 +229,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_unset_on_property' => false,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_return' => false,
+        'no_useless_return' => true,
         'no_useless_sprintf' => false,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_return` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/return_notation/no_useless_return.rst.