### PR TITLE
Enhancement: Enable no_useless_sprintf fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_unneeded_final_method` fixer ([#48]), by [@localheinz]
 * Enabled `no_unreachable_default_argument_value` fixer ([#49]), by [@localheinz]
 * Enabled `no_useless_return` fixer ([#50]), by [@localheinz]
+* Enabled `no_useless_sprintf` fixer ([#51]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -100,5 +101,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#48]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/48
 [#49]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/49
 [#50]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/50
+[#51]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/51
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -224,7 +224,7 @@ final class Php72 extends AbstractRuleSet
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -224,7 +224,7 @@ final class Php74 extends AbstractRuleSet
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -230,7 +230,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -230,7 +230,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_sprintf` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/no_useless_sprintf.rst.