### PR TITLE
Enhancement: Enable nullable_type_declaration_for_default_null_value fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_unreachable_default_argument_value` fixer ([#49]), by [@localheinz]
 * Enabled `no_useless_return` fixer ([#50]), by [@localheinz]
 * Enabled `no_useless_sprintf` fixer ([#51]), by [@localheinz]
+* Enabled `nullable_type_declaration_for_default_null_value` fixer ([#52]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -102,5 +103,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#49]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/49
 [#50]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/50
 [#51]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/51
+[#52]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/52
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -231,7 +231,7 @@ final class Php72 extends AbstractRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'operator_linebreak' => false,
         'ordered_class_elements' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -231,7 +231,7 @@ final class Php74 extends AbstractRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'operator_linebreak' => false,
         'ordered_class_elements' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -237,7 +237,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'operator_linebreak' => false,
         'ordered_class_elements' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -237,7 +237,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'operator_linebreak' => false,
         'ordered_class_elements' => true,


### PR DESCRIPTION
This PR

* [x] enables the `nullable_type_declaration_for_default_null_value` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst.