### PR TITLE
Enhancement: Enable and configure operator_linebreak fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_useless_return` fixer ([#50]), by [@localheinz]
 * Enabled `no_useless_sprintf` fixer ([#51]), by [@localheinz]
 * Enabled `nullable_type_declaration_for_default_null_value` fixer ([#52]), by [@localheinz]
+* Enabled and configured `operator_linebreak` fixer ([#53]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -104,5 +105,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#50]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/50
 [#51]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/51
 [#52]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/52
+[#53]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/53
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -233,7 +233,10 @@ final class Php72 extends AbstractRuleSet
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -233,7 +233,10 @@ final class Php74 extends AbstractRuleSet
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -239,7 +239,10 @@ final class Php72Test extends AbstractRuleSetTestCase
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -239,7 +239,10 @@ final class Php74Test extends AbstractRuleSetTestCase
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [


### PR DESCRIPTION
This PR

* [x] enables and configures the `operator_linebreak` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/operator/operator_linebreak.rst.