### PR TITLE
Enhancement: Enable ordered_interfaces fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `no_useless_sprintf` fixer ([#51]), by [@localheinz]
 * Enabled `nullable_type_declaration_for_default_null_value` fixer ([#52]), by [@localheinz]
 * Enabled and configured `operator_linebreak` fixer ([#53]), by [@localheinz]
+* Enabled `ordered_interfaces` fixer ([#54]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -106,5 +107,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#51]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/51
 [#52]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/52
 [#53]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/53
+[#54]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/54
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -245,7 +245,7 @@ final class Php72 extends AbstractRuleSet
                 Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
             ],
         ],
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'ordered_traits' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -245,7 +245,7 @@ final class Php74 extends AbstractRuleSet
                 Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
             ],
         ],
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'ordered_traits' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -251,7 +251,7 @@ final class Php72Test extends AbstractRuleSetTestCase
                 Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
             ],
         ],
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'ordered_traits' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -251,7 +251,7 @@ final class Php74Test extends AbstractRuleSetTestCase
                 Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
             ],
         ],
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'ordered_traits' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [


### PR DESCRIPTION
This PR

* [x] enables and configures the `ordered_interfaces` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/class_notation/ordered_interfaces.rst.