### PR TITLE
Enhancement: Enable php_unit_mock fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `ordered_interfaces` fixer ([#54]), by [@localheinz]
 * Enabled `php_unit_expectation` fixer ([#56]), by [@localheinz]
 * Enabled `php_unit_internal_class` fixer ([#57]), by [@localheinz]
+* Enabled `php_unit_mock` fixer ([#58]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -112,5 +113,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#54]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/54
 [#56]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/56
 [#57]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/57
+[#58]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/58
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -256,7 +256,7 @@ final class Php72 extends AbstractRuleSet
         'php_unit_fqcn_annotation' => true,
         'php_unit_internal_class' => true,
         'php_unit_method_casing' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => false,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -256,7 +256,7 @@ final class Php74 extends AbstractRuleSet
         'php_unit_fqcn_annotation' => true,
         'php_unit_internal_class' => true,
         'php_unit_method_casing' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => false,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -262,7 +262,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'php_unit_fqcn_annotation' => true,
         'php_unit_internal_class' => true,
         'php_unit_method_casing' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => false,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -262,7 +262,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'php_unit_fqcn_annotation' => true,
         'php_unit_internal_class' => true,
         'php_unit_method_casing' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => false,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_mock` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/php_unit/php_unit_mock.rst.