### PR TITLE
Enhancement: Enable php_unit_namespaced fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `php_unit_internal_class` fixer ([#57]), by [@localheinz]
 * Enabled `php_unit_mock` fixer ([#58]), by [@localheinz]
 * Enabled `php_unit_mock_short_will_return` fixer ([#59]), by [@localheinz]
+* Enabled `php_unit_namespaced` fixer ([#60]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -116,5 +117,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#57]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/57
 [#58]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/58
 [#59]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/59
+[#60]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/60
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -258,7 +258,7 @@ final class Php72 extends AbstractRuleSet
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_size_class' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -258,7 +258,7 @@ final class Php74 extends AbstractRuleSet
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_size_class' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -264,7 +264,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_size_class' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -264,7 +264,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_size_class' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_namespaced` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/php_unit/php_unit_namespaced.rst.