### PR TITLE
Enhancement: Enable php_unit_set_up_tear_down_visibility fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `php_unit_mock_short_will_return` fixer ([#59]), by [@localheinz]
 * Enabled `php_unit_namespaced` fixer ([#60]), by [@localheinz]
 * Enabled `php_unit_no_expectation_annotation` fixer ([#61]), by [@localheinz]
+* Enabled `php_unit_set_up_tear_down_visibility` fixer ([#62]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -120,5 +121,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#59]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/59
 [#60]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/60
 [#61]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/61
+[#62]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/62
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -260,7 +260,7 @@ final class Php72 extends AbstractRuleSet
         'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -260,7 +260,7 @@ final class Php74 extends AbstractRuleSet
         'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -266,7 +266,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -266,7 +266,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_set_up_tear_down_visibility` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.rst.