### PR TITLE
Enhancement: Enable and configure phpdoc_line_span fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `php_unit_namespaced` fixer ([#60]), by [@localheinz]
 * Enabled `php_unit_no_expectation_annotation` fixer ([#61]), by [@localheinz]
 * Enabled `php_unit_set_up_tear_down_visibility` fixer ([#62]), by [@localheinz]
+* Enabled and configured `phpdoc_line_span` fixer ([#63]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -122,5 +123,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#60]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/60
 [#61]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/61
 [#62]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/62
+[#63]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/63
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -285,7 +285,11 @@ final class Php72 extends AbstractRuleSet
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag_normalizer' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -285,7 +285,11 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag_normalizer' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -291,7 +291,11 @@ final class Php72Test extends AbstractRuleSetTestCase
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag_normalizer' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -291,7 +291,11 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag_normalizer' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_line_span` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/phpdoc_line_span.rst.