### PR TITLE
Enhancement: Enable phpdoc_order fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `php_unit_no_expectation_annotation` fixer ([#61]), by [@localheinz]
 * Enabled `php_unit_set_up_tear_down_visibility` fixer ([#62]), by [@localheinz]
 * Enabled and configured `phpdoc_line_span` fixer ([#63]), by [@localheinz]
+* Enabled `phpdoc_order` fixer ([#64]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -124,5 +125,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#61]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/61
 [#62]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/62
 [#63]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/63
+[#64]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/64
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -295,7 +295,7 @@ final class Php72 extends AbstractRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => false,
+        'phpdoc_order' => true,
         'phpdoc_order_by_value' => false,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -295,7 +295,7 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => false,
+        'phpdoc_order' => true,
         'phpdoc_order_by_value' => false,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -301,7 +301,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => false,
+        'phpdoc_order' => true,
         'phpdoc_order_by_value' => false,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -301,7 +301,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => false,
+        'phpdoc_order' => true,
         'phpdoc_order_by_value' => false,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_order` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/phpdoc_order.rst.