### PR TITLE
Enhancement: Enable phpdoc_tag_casing fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `php_unit_set_up_tear_down_visibility` fixer ([#62]), by [@localheinz]
 * Enabled and configured `phpdoc_line_span` fixer ([#63]), by [@localheinz]
 * Enabled `phpdoc_order` fixer ([#64]), by [@localheinz]
+* Enabled `phpdoc_tag_casing` fixer ([#65]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -126,5 +127,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#62]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/62
 [#63]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/63
 [#64]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/64
+[#65]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/65
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -302,7 +302,7 @@ final class Php72 extends AbstractRuleSet
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => true,
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritDoc' => 'inline',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -302,7 +302,7 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => true,
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritDoc' => 'inline',

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -308,7 +308,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => true,
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritDoc' => 'inline',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -308,7 +308,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => true,
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritDoc' => 'inline',


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_tag_casing` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/phpdoc_tag_casing.rst.