### PR TITLE
Enhancement: Enable phpdoc_var_annotation_correct_order fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `phpdoc_order` fixer ([#64]), by [@localheinz]
 * Enabled `phpdoc_tag_casing` fixer ([#65]), by [@localheinz]
 * Enabled and configured `phpdoc_order_by_value` fixer ([#66]), by [@localheinz]
+* Enabled `phpdoc_var_annotation_correct_order` fixer ([#67]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -130,5 +131,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#64]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/64
 [#65]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/65
 [#66]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/66
+[#67]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/67
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -330,7 +330,7 @@ final class Php72 extends AbstractRuleSet
             'null_adjustment' => 'always_last',
             'sort_algorithm' => 'none',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => false,
         'protected_to_private' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -330,7 +330,7 @@ final class Php74 extends AbstractRuleSet
             'null_adjustment' => 'always_last',
             'sort_algorithm' => 'none',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => false,
         'protected_to_private' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -336,7 +336,7 @@ final class Php72Test extends AbstractRuleSetTestCase
             'null_adjustment' => 'always_last',
             'sort_algorithm' => 'none',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => false,
         'protected_to_private' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -336,7 +336,7 @@ final class Php74Test extends AbstractRuleSetTestCase
             'null_adjustment' => 'always_last',
             'sort_algorithm' => 'none',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => false,
         'protected_to_private' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_var_annotation_correct_order` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/phpdoc_var_annotation_correct_order.rst.