### PR TITLE
Enhancement: Enable pow_to_exponentiation fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `phpdoc_tag_casing` fixer ([#65]), by [@localheinz]
 * Enabled and configured `phpdoc_order_by_value` fixer ([#66]), by [@localheinz]
 * Enabled `phpdoc_var_annotation_correct_order` fixer ([#67]), by [@localheinz]
+* Enabled `pow_to_exponentiation` fixer ([#68]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -132,5 +133,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#65]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/65
 [#66]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/66
 [#67]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/67
+[#68]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/68
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -332,7 +332,7 @@ final class Php72 extends AbstractRuleSet
         ],
         'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
-        'pow_to_exponentiation' => false,
+        'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -332,7 +332,7 @@ final class Php74 extends AbstractRuleSet
         ],
         'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
-        'pow_to_exponentiation' => false,
+        'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -338,7 +338,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         ],
         'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
-        'pow_to_exponentiation' => false,
+        'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -338,7 +338,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         ],
         'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
-        'pow_to_exponentiation' => false,
+        'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => false,


### PR DESCRIPTION
This PR

* [x] enables the `pow_to_exponentiation` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/alias/pow_to_exponentiation.rst.