### PR TITLE
Enhancement: Enable random_api_migration fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled and configured `phpdoc_order_by_value` fixer ([#66]), by [@localheinz]
 * Enabled `phpdoc_var_annotation_correct_order` fixer ([#67]), by [@localheinz]
 * Enabled `pow_to_exponentiation` fixer ([#68]), by [@localheinz]
+* Enabled `random_api_migration` fixer ([#69]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -134,5 +135,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#66]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/66
 [#67]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/67
 [#68]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/68
+[#69]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/69
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -335,7 +335,7 @@ final class Php72 extends AbstractRuleSet
         'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
-        'random_api_migration' => false,
+        'random_api_migration' => true,
         'regular_callable_call' => false,
         'return_assignment' => false,
         'return_type_declaration' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -335,7 +335,7 @@ final class Php74 extends AbstractRuleSet
         'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
-        'random_api_migration' => false,
+        'random_api_migration' => true,
         'regular_callable_call' => false,
         'return_assignment' => false,
         'return_type_declaration' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -341,7 +341,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
-        'random_api_migration' => false,
+        'random_api_migration' => true,
         'regular_callable_call' => false,
         'return_assignment' => false,
         'return_type_declaration' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -341,7 +341,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'psr_autoloading' => true,
-        'random_api_migration' => false,
+        'random_api_migration' => true,
         'regular_callable_call' => false,
         'return_assignment' => false,
         'return_type_declaration' => true,


### PR DESCRIPTION
This PR

* [x] enables the `random_api_migration` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/alias/random_api_migration.rst.