### PR TITLE
Enhancement: Enable regular_callable_call fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `phpdoc_var_annotation_correct_order` fixer ([#67]), by [@localheinz]
 * Enabled `pow_to_exponentiation` fixer ([#68]), by [@localheinz]
 * Enabled `random_api_migration` fixer ([#69]), by [@localheinz]
+* Enabled `regular_callable_call` fixer ([#70]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -136,5 +137,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#67]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/67
 [#68]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/68
 [#69]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/69
+[#70]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/70
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -336,7 +336,7 @@ final class Php72 extends AbstractRuleSet
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
-        'regular_callable_call' => false,
+        'regular_callable_call' => true,
         'return_assignment' => false,
         'return_type_declaration' => true,
         'self_accessor' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -336,7 +336,7 @@ final class Php74 extends AbstractRuleSet
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
-        'regular_callable_call' => false,
+        'regular_callable_call' => true,
         'return_assignment' => false,
         'return_type_declaration' => true,
         'self_accessor' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -342,7 +342,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
-        'regular_callable_call' => false,
+        'regular_callable_call' => true,
         'return_assignment' => false,
         'return_type_declaration' => true,
         'self_accessor' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -342,7 +342,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
-        'regular_callable_call' => false,
+        'regular_callable_call' => true,
         'return_assignment' => false,
         'return_type_declaration' => true,
         'self_accessor' => false,


### PR DESCRIPTION
This PR

* [x] enables the `regular_callable_call` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/regular_callable_call.rst.