### PR TITLE
Enhancement: Enable return_assignment fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ For a full diff see [`1.2.0...main`][1.2.0...main].
 * Enabled `pow_to_exponentiation` fixer ([#68]), by [@localheinz]
 * Enabled `random_api_migration` fixer ([#69]), by [@localheinz]
 * Enabled `regular_callable_call` fixer ([#70]), by [@localheinz]
+* Enabled `return_assignment` fixer ([#71]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -138,5 +139,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#68]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/68
 [#69]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/69
 [#70]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/70
+[#71]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/71
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -337,7 +337,7 @@ final class Php72 extends AbstractRuleSet
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'regular_callable_call' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => false,
         'self_static_accessor' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -337,7 +337,7 @@ final class Php74 extends AbstractRuleSet
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'regular_callable_call' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => false,
         'self_static_accessor' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -343,7 +343,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'regular_callable_call' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => false,
         'self_static_accessor' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -343,7 +343,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'regular_callable_call' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => false,
         'self_static_accessor' => false,


### PR DESCRIPTION
This PR

* [x] enables the `return_assignment` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/return_notation/return_assignment.rst.