### PR TITLE
Enhancement: Enable self_accessor fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `random_api_migration` fixer ([#69]), by [@localheinz]
 * Enabled `regular_callable_call` fixer ([#70]), by [@localheinz]
 * Enabled `return_assignment` fixer ([#71]), by [@localheinz]
+* Enabled `self_accessor` fixer ([#73]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -149,5 +150,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#69]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/69
 [#70]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/70
 [#71]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/71
+[#73]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/73
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -339,7 +339,7 @@ final class Php72 extends AbstractRuleSet
         'regular_callable_call' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
-        'self_accessor' => false,
+        'self_accessor' => true,
         'self_static_accessor' => false,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -339,7 +339,7 @@ final class Php74 extends AbstractRuleSet
         'regular_callable_call' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
-        'self_accessor' => false,
+        'self_accessor' => true,
         'self_static_accessor' => false,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -345,7 +345,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'regular_callable_call' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
-        'self_accessor' => false,
+        'self_accessor' => true,
         'self_static_accessor' => false,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -345,7 +345,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'regular_callable_call' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
-        'self_accessor' => false,
+        'self_accessor' => true,
         'self_static_accessor' => false,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,


### PR DESCRIPTION
This PR

* [x] enables the `self_accessor` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/class_notation/self_accessor.rst.