### PR TITLE
Enhancement: Enable self_static_accessor fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `regular_callable_call` fixer ([#70]), by [@localheinz]
 * Enabled `return_assignment` fixer ([#71]), by [@localheinz]
 * Enabled `self_accessor` fixer ([#73]), by [@localheinz]
+* Enabled `self_static_accessor` fixer ([#74]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -151,5 +152,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#70]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/70
 [#71]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/71
 [#73]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/73
+[#74]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/74
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -340,7 +340,7 @@ final class Php72 extends AbstractRuleSet
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,
         'short_scalar_cast' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -340,7 +340,7 @@ final class Php74 extends AbstractRuleSet
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,
         'short_scalar_cast' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -346,7 +346,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,
         'short_scalar_cast' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -346,7 +346,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => false,
         'short_scalar_cast' => true,


### PR DESCRIPTION
This PR

* [x] enables the `self_static_accessor` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/class_notation/self_static_accessor.rst.