### PR TITLE
Enhancement: Enable set_type_to_cast fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `return_assignment` fixer ([#71]), by [@localheinz]
 * Enabled `self_accessor` fixer ([#73]), by [@localheinz]
 * Enabled `self_static_accessor` fixer ([#74]), by [@localheinz]
+* Enabled `set_type_to_cast` fixer ([#75]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -153,5 +154,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#71]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/71
 [#73]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/73
 [#74]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/74
+[#75]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/75
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -342,7 +342,7 @@ final class Php72 extends AbstractRuleSet
         'self_accessor' => true,
         'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'simple_to_complex_string_variable' => false,
         'simplified_if_return' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -342,7 +342,7 @@ final class Php74 extends AbstractRuleSet
         'self_accessor' => true,
         'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'simple_to_complex_string_variable' => false,
         'simplified_if_return' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -348,7 +348,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'self_accessor' => true,
         'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'simple_to_complex_string_variable' => false,
         'simplified_if_return' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -348,7 +348,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'self_accessor' => true,
         'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'simple_to_complex_string_variable' => false,
         'simplified_if_return' => false,


### PR DESCRIPTION
This PR

* [x] enables the `self_static_accessor` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/alias/set_type_to_cast.rst.