### PR TITLE
Enhancement: Enable simple_to_complex_string_variable fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `self_accessor` fixer ([#73]), by [@localheinz]
 * Enabled `self_static_accessor` fixer ([#74]), by [@localheinz]
 * Enabled `set_type_to_cast` fixer ([#75]), by [@localheinz]
+* Enabled `simple_to_complex_string_variable` fixer ([#76]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -155,5 +156,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#73]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/73
 [#74]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/74
 [#75]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/75
+[#76]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/76
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -344,7 +344,7 @@ final class Php72 extends AbstractRuleSet
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_if_return' => false,
         'simplified_null_return' => false,
         'single_blank_line_at_eof' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -344,7 +344,7 @@ final class Php74 extends AbstractRuleSet
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_if_return' => false,
         'simplified_null_return' => false,
         'single_blank_line_at_eof' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -350,7 +350,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_if_return' => false,
         'simplified_null_return' => false,
         'single_blank_line_at_eof' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -350,7 +350,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_if_return' => false,
         'simplified_null_return' => false,
         'single_blank_line_at_eof' => true,


### PR DESCRIPTION
This PR

* [x] enables the `simple_to_complex_string_variable` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/string_notation/simple_to_complex_string_variable.rst.