### PR TITLE
Enhancement: Enable string_line_ending fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `self_static_accessor` fixer ([#74]), by [@localheinz]
 * Enabled `set_type_to_cast` fixer ([#75]), by [@localheinz]
 * Enabled `simple_to_complex_string_variable` fixer ([#76]), by [@localheinz]
+* Enabled `string_line_ending` fixer ([#77]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -157,5 +158,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#74]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/74
 [#75]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/75
 [#76]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/76
+[#77]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/77
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -369,7 +369,7 @@ final class Php72 extends AbstractRuleSet
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
         'switch_continue_to_break' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -369,7 +369,7 @@ final class Php74 extends AbstractRuleSet
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
         'switch_continue_to_break' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -375,7 +375,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
         'switch_continue_to_break' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -375,7 +375,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
         'switch_continue_to_break' => true,


### PR DESCRIPTION
This PR

* [x] enables the `string_line_ending` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/string_notation/string_line_ending.rst.