### PR TITLE
Enhancement: Enable ternary_to_elvis_operator fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `set_type_to_cast` fixer ([#75]), by [@localheinz]
 * Enabled `simple_to_complex_string_variable` fixer ([#76]), by [@localheinz]
 * Enabled `string_line_ending` fixer ([#77]), by [@localheinz]
+* Enabled `ternary_to_elvis_operator` fixer ([#78]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -159,5 +160,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#75]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/75
 [#76]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/76
 [#77]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/77
+[#78]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/78
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -374,7 +374,7 @@ final class Php72 extends AbstractRuleSet
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -374,7 +374,7 @@ final class Php74 extends AbstractRuleSet
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -380,7 +380,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -380,7 +380,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,


### PR DESCRIPTION
This PR

* [x] enables the `ternary_to_elvis_operator` fixer

Follows #25.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/operator/ternary_to_elvis_operator.rst.