### PR TITLE
Fix: Covers annotation

### DIFF
--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -19,7 +19,7 @@ use PhpCsFixer\Fixer;
  * @internal
  *
  * @covers \Gansel\PhpCsFixer\Config\RuleSet\AbstractRuleSet
- * @covers \Gansel\PhpCsFixer\Config\RuleSet\Php74
+ * @covers \Gansel\PhpCsFixer\Config\RuleSet\Php72
  */
 final class Php72Test extends AbstractRuleSetTestCase
 {


### PR DESCRIPTION
This PR

* [x] fixes a `@covers` annotation