### PR TITLE
Enhancement: Configure no_whitespace_before_comma_in_array differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `string_line_ending` fixer ([#77]), by [@localheinz]
 * Enabled `ternary_to_elvis_operator` fixer ([#78]), by [@localheinz]
 * Added rule set for PHP 7.3 ([#80]), by [@localheinz]
+* Configured `no_whitespace_before_comma_in_array` differently for `Php72`, `Php73`, and `Php74` rule sets ([#81]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 
@@ -163,5 +164,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#77]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/77
 [#78]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/78
 [#80]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/80
+[#81]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/81
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -225,7 +225,9 @@ final class Php72 extends AbstractRuleSet
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => false,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,
         'normalize_index_brace' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -225,7 +225,9 @@ final class Php73 extends AbstractRuleSet
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,
         'normalize_index_brace' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -225,7 +225,9 @@ final class Php74 extends AbstractRuleSet
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,
         'normalize_index_brace' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -231,7 +231,9 @@ final class Php72Test extends AbstractRuleSetTestCase
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => false,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,
         'normalize_index_brace' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -231,7 +231,9 @@ final class Php73Test extends AbstractRuleSetTestCase
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,
         'normalize_index_brace' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -231,7 +231,9 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => false,
         'normalize_index_brace' => true,


### PR DESCRIPTION
This PR

* [x] configures the `no_whitespace_before_comma_in_array` differently depending on the targeted PHP version

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst.