### PR TITLE
Enhancement: Configure trailing_comma_in_multiline_array differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ For a full diff see [`1.2.1...main`][1.2.1...main].
 * Enabled `ternary_to_elvis_operator` fixer ([#78]), by [@localheinz]
 * Added rule set for PHP 7.3 ([#80]), by [@localheinz]
 * Configured `no_whitespace_before_comma_in_array` differently for `Php72`, `Php73`, and `Php74` rule sets ([#81]), by [@localheinz]
+* Configured `trailing_comma_in_multiline_array` differently for `Php72`, `Php73`, and `Php74` rule sets ([#81]), by [@localheinz]
 
 ## [`1.2.1`][1.2.1]
 

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -378,7 +378,9 @@ final class Php72 extends AbstractRuleSet
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => false,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -378,7 +378,9 @@ final class Php73 extends AbstractRuleSet
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -378,7 +378,9 @@ final class Php74 extends AbstractRuleSet
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -384,7 +384,9 @@ final class Php72Test extends AbstractRuleSetTestCase
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => false,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -384,7 +384,9 @@ final class Php73Test extends AbstractRuleSetTestCase
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -384,7 +384,9 @@ final class Php74Test extends AbstractRuleSetTestCase
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,


### PR DESCRIPTION
This PR

* [x] configures the `trailing_comma_in_multiline_array` differently depending on the targeted PHP version

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/array_notation/trailing_comma_in_multiline_array.rst.