### PR TITLE
Enhancement: Configure method_argument_space fixer differently

### DIFF
--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -140,6 +140,7 @@ final class Php72 extends AbstractRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
+            'after_heredoc' => false,
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -140,6 +140,7 @@ final class Php73 extends AbstractRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
+            'after_heredoc' => true,
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -140,6 +140,7 @@ final class Php74 extends AbstractRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
+            'after_heredoc' => true,
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -146,6 +146,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
+            'after_heredoc' => false,
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -146,6 +146,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
+            'after_heredoc' => true,
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -146,6 +146,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
+            'after_heredoc' => true,
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,


### PR DESCRIPTION
This PR

* [x] configures the `method_argument_space` differently depending on the targeted PHP version

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/method_argument_space.rst.