### PR TITLE
Enhancement: Configure native_constant_invocation fixer to ignore built-in constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.3.0...main`][1.3.0...main].
+For a full diff see [`1.3.0...main`][1.4.0...main].
 
-## [`1.3.01`][1.3.0]
+## [`1.4.0`][1.4.0]
+
+For a full diff see [`1.3.0...1.4.0`][1.3.0...1.4.0].
+
+### Changed
+
+* Configured `native_constant_invocation` fixer to ignore built-in constants ([#85]), by [@localheinz]
+
+## [`1.3.0`][1.3.0]
 
 For a full diff see [`1.2.1...1.3.0`][1.2.1...1.3.0].
 
@@ -111,13 +119,15 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [1.2.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/tag/1.2.0
 [1.2.1]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/tag/1.2.0
 [1.3.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/tag/1.3.0
+[1.4.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/tag/1.4.0
 
 [b9012df...1.0.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/b9012df...1.0.0
 [1.0.0...1.1.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.0.0...1.1.0
 [1.1.0...1.2.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.1.0...1.2.0
 [1.2.0...1.2.1]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.2.0...1.2.1
 [1.2.1...1.3.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.2.1...1.3.0
-[1.3.0...main]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.3.0...main
+[1.3.0...1.4.0]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.3.0...1.4.0
+[1.4.0...main]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/compare/1.4.0...main
 
 [#9]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/9
 [#11]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/11
@@ -175,5 +185,6 @@ For a full diff see [`b9012df...1.0.0`][b9012df...1.0.0].
 [#78]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/78
 [#80]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/80
 [#81]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/81
+[#85]: https://github.com/gansel-rechtsanwaelte/php-cs-fixer-config/pull/85
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -147,7 +147,9 @@ final class Php72 extends AbstractRuleSet
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => true,
+        'native_constant_invocation' => [
+            'fix_built_in' => false,
+        ],
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -147,7 +147,9 @@ final class Php73 extends AbstractRuleSet
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => true,
+        'native_constant_invocation' => [
+            'fix_built_in' => false,
+        ],
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -147,7 +147,9 @@ final class Php74 extends AbstractRuleSet
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => true,
+        'native_constant_invocation' => [
+            'fix_built_in' => false,
+        ],
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -153,7 +153,9 @@ final class Php72Test extends AbstractRuleSetTestCase
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => true,
+        'native_constant_invocation' => [
+            'fix_built_in' => false,
+        ],
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -153,7 +153,9 @@ final class Php73Test extends AbstractRuleSetTestCase
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => true,
+        'native_constant_invocation' => [
+            'fix_built_in' => false,
+        ],
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -153,7 +153,9 @@ final class Php74Test extends AbstractRuleSetTestCase
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_constant_invocation' => true,
+        'native_constant_invocation' => [
+            'fix_built_in' => false,
+        ],
         'native_function_casing' => true,
         'native_function_invocation' => [
             'include' => [


### PR DESCRIPTION
This PR

* [x] configures the `native_constant_invocation` fixer to ignore built-in constants